### PR TITLE
initialize outfile

### DIFF
--- a/tools/picorbc/picorbc.c
+++ b/tools/picorbc/picorbc.c
@@ -109,7 +109,7 @@ int main(int argc, char * const *argv)
   struct picorbc_args args = {0};
   args.argv = (char **)argv;
   args.argc = argc;
-  char outfile[255];
+  char outfile[255] = {0};
   char initname[255] = {0};
   args.outfile = outfile;
   args.initname = initname;


### PR DESCRIPTION
without `-o` option,

Now: saved in current directory in random filename

To be: saved in input file's directory in same basename and `.c` extname (ex: input `/path/to/keyboard.rb`-> output `/path/to/keyboard.c` )